### PR TITLE
feat: unify header with AppHeader + LanguagePicker (#21)

### DIFF
--- a/.artefacts/BRIEF.md
+++ b/.artefacts/BRIEF.md
@@ -22,6 +22,7 @@ Transparent salary formula explorer: factors, scenarios, saved comparisons. Reac
 - [x] Factor contribution breakdown chart (#12) — compact breakdown section in `SalaryCalculator.tsx` between result card and currency selector; per-factor horizontal progress bars (pure CSS, Tailwind); each bar shows factor label + percentage of total multiplier sum; updates reactively as sliders move; `calculator.breakdown_title` i18n key in all 4 locales (EN/ES/BE/RU)
 - [x] Team Identity import (#13) — "Import from Team Identity" button below save-profile form in `SalaryCalculator.tsx`; reads `team-identity:charter` localStorage key; shows member picker when >1 member; pre-fills profile name input; `calculator.ti_import` / `calculator.ti_no_data` i18n keys in all 4 locales (EN/ES/BE/RU)
 - [x] Formula review date reminder (#14) — "Mark as reviewed" button in `FormulaBuilder.tsx` writes `salary-formula:lastReviewed` ISO timestamp; yellow banner in `SalaryCalculator.tsx` if key absent or >180 days old; dismiss button (session-only, no review date update); `calculator.review_due` / `calculator.review_dismiss` / `builder.mark_reviewed` / `builder.review_done` i18n keys in all 4 locales (EN/ES/BE/RU)
+- [x] Header unification (#21) — `AppHeader.tsx` + `LanguagePicker.tsx` copied from design-system into `src/components/`; inline cycle-button header replaced; navItems with active state; language picker shows current code with dropdown; nav hidden on home screen
 
 ## Backlog
 
@@ -59,6 +60,12 @@ Transparent salary formula explorer: factors, scenarios, saved comparisons. Reac
 - No backend; all client-side.
 
 ## Agent Log
+
+### 2026-06-27 — feat: header unification (#21)
+- Done: copied `AppHeader.tsx` and `LanguagePicker.tsx` from design-system into `src/components/`; replaced inline header in `App.tsx` with `<AppHeader title onTitleClick navItems>`; navItems built with active state and hide on home screen; removed cycle-button language switcher; also installed missing `html2canvas` dep to fix pre-existing build error
+- Issue #21 status → In Review
+- Remaining: #22 (light/dark theme — auto-approved, ≥38 days stale, eligible)
+- Next task: implement #22 (light/dark theme — `darkMode: 'class'` in tailwind.config.js; anti-flash inline script in index.html; copy ThemeToggle.tsx from design-system; add `<ThemeToggle />` inside AppHeader children slot; add `dark:` variants across all src/ Tailwind color classes per token map in design-system/tokens.css)
 
 ### 2026-06-24 — feat: formula review date reminder (#14)
 - Done: added `LAST_REVIEWED_KEY = 'salary-formula:lastReviewed'` constant and `handleMarkReviewed()` in `FormulaBuilder.tsx`; "Mark as reviewed" button added to header action row with 2s "Review recorded!" flash; `reviewOverdue` computed via `useMemo` in `SalaryCalculator.tsx` (true if key absent or >180 days old); yellow banner shown above result card when overdue and not dismissed; dismiss is session-only (component state); `calculator.review_due`, `calculator.review_dismiss`, `builder.mark_reviewed`, `builder.review_done` i18n keys added to all 4 locales (EN/ES/BE/RU); `salary-formula:lastReviewed` documented in localStorage keys table

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { Screen, Factor, FormulaConfig, Profile, Scenario } from './types'
 import { DEFAULT_FACTORS } from './data/presets'
+import AppHeader from './components/AppHeader'
 import HomeScreen from './components/HomeScreen'
 import SalaryCalculator from './components/SalaryCalculator'
 import FormulaBuilder from './components/FormulaBuilder'
@@ -105,7 +106,7 @@ function writeLastSession(
 }
 
 export default function App() {
-  const { t, i18n } = useTranslation()
+  const { t } = useTranslation()
   const [screen, setScreen] = useState<Screen>('home')
   const fromHash = loadFromHash()
   const [factors, setFactors] = useState<Factor[]>(fromHash?.factors ?? DEFAULT_FACTORS)
@@ -152,14 +153,16 @@ export default function App() {
     saveScenarios(updated)
   }
 
-  const navItems: { key: Screen; label: string }[] = [
-    { key: 'calculator', label: t('nav.calculator') },
-    { key: 'builder', label: t('nav.builder') },
-    { key: 'comparison', label: t('nav.comparison') },
-    { key: 'scenarios', label: t('nav.scenarios') },
-    { key: 'equity', label: t('nav.equity') },
-    { key: 'learn', label: t('nav.learn') },
-  ]
+  const navItems = screen !== 'home'
+    ? [
+        { key: 'calculator', label: t('nav.calculator'), active: screen === 'calculator', onClick: () => setScreen('calculator') },
+        { key: 'builder', label: t('nav.builder'), active: screen === 'builder', onClick: () => setScreen('builder') },
+        { key: 'comparison', label: t('nav.comparison'), active: screen === 'comparison', onClick: () => setScreen('comparison') },
+        { key: 'scenarios', label: t('nav.scenarios'), active: screen === 'scenarios', onClick: () => setScreen('scenarios') },
+        { key: 'equity', label: t('nav.equity'), active: screen === 'equity', onClick: () => setScreen('equity') },
+        { key: 'learn', label: t('nav.learn'), active: screen === 'learn', onClick: () => setScreen('learn') },
+      ]
+    : []
 
   return (
     <div className="min-h-screen flex flex-col" data-accent="cobalt">
@@ -169,60 +172,11 @@ export default function App() {
       >
         {t('app.skip_to_content')}
       </a>
-      <header className="bg-white border-b border-gray-200 sticky top-0 z-10">
-        <div className="max-w-3xl mx-auto px-4 h-14 flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <a
-              href="https://agile-toolkit.github.io/"
-              title="Agile Toolkit"
-              className="text-gray-400 hover:text-gray-600 transition-colors flex-shrink-0"
-            >
-              <svg className="w-4 h-4" viewBox="0 0 16 16" fill="currentColor">
-                <rect x="1" y="1" width="6" height="6" rx="1"/>
-                <rect x="9" y="1" width="6" height="6" rx="1"/>
-                <rect x="1" y="9" width="6" height="6" rx="1"/>
-                <rect x="9" y="9" width="6" height="6" rx="1"/>
-              </svg>
-            </a>
-            <button
-              onClick={() => setScreen('home')}
-              className="font-semibold text-brand-600 hover:text-brand-700 transition-colors"
-            >
-              {t('app.title')}
-            </button>
-          </div>
-          <div className="flex items-center gap-1">
-            {screen !== 'home' &&
-              navItems.map(item => (
-                <button
-                  key={item.key}
-                  onClick={() => setScreen(item.key)}
-                  className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
-                    screen === item.key
-                      ? 'bg-brand-100 text-brand-700'
-                      : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100'
-                  }`}
-                >
-                  {item.label}
-                </button>
-              ))}
-            <button
-              onClick={() => {
-                const langs = ['en', 'es', 'be', 'ru']
-                const current = langs.find(l => i18n.language.startsWith(l)) ?? 'en'
-                i18n.changeLanguage(langs[(langs.indexOf(current) + 1) % langs.length])
-              }}
-              className="ml-2 text-sm text-gray-500 hover:text-gray-700 px-2 py-1 rounded hover:bg-gray-100 transition-colors"
-            >
-              {(() => {
-                const langs = ['en', 'es', 'be', 'ru']
-                const current = langs.find(l => i18n.language.startsWith(l)) ?? 'en'
-                return langs[(langs.indexOf(current) + 1) % langs.length].toUpperCase()
-              })()}
-            </button>
-          </div>
-        </div>
-      </header>
+      <AppHeader
+        title={t('app.title')}
+        onTitleClick={() => setScreen('home')}
+        navItems={navItems}
+      />
 
       <main id="main-content" className="flex-1 max-w-3xl mx-auto w-full px-4 py-8">
         {screen === 'home' && <HomeScreen onStart={() => setScreen('calculator')} />}

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,0 +1,102 @@
+import LanguagePicker from './LanguagePicker'
+
+/**
+ * Copy this file (and LanguagePicker.tsx) into src/components/ when adopting in an app.
+ * Requires: react-i18next.
+ *
+ * Usage:
+ *   <AppHeader title={t('app.title')} onTitleClick={reset}>
+ *     {/* optional extra controls placed right of LanguagePicker *\/}
+ *   </AppHeader>
+ *
+ *   <AppHeader
+ *     title={t('app.title')}
+ *     onTitleClick={() => setScreen('home')}
+ *     navItems={[
+ *       { key: 'settings', label: t('nav.settings'), active: screen === 'settings', onClick: () => setScreen('settings') },
+ *     ]}
+ *   />
+ */
+
+interface NavItem {
+  key: string
+  label: string
+  active: boolean
+  onClick: () => void
+}
+
+interface AppHeaderProps {
+  title: string
+  onTitleClick?: () => void
+  navItems?: NavItem[]
+  children?: React.ReactNode
+}
+
+const DASHBOARD_URL = 'https://agile-toolkit.github.io/'
+
+const GridIcon = () => (
+  <svg className="w-4 h-4" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+    <rect x="1" y="1" width="6" height="6" rx="1"/>
+    <rect x="9" y="1" width="6" height="6" rx="1"/>
+    <rect x="1" y="9" width="6" height="6" rx="1"/>
+    <rect x="9" y="9" width="6" height="6" rx="1"/>
+  </svg>
+)
+
+export default function AppHeader({ title, onTitleClick, navItems, children }: AppHeaderProps) {
+  return (
+    <header className="bg-white border-b border-gray-200 sticky top-0 z-10">
+      <div className="max-w-5xl mx-auto px-4 h-14 flex items-center justify-between gap-4">
+
+        {/* Left: dashboard link + app title */}
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <a
+            href={DASHBOARD_URL}
+            title="Agile Toolkit — back to dashboard"
+            className="text-gray-400 hover:text-gray-600 transition-colors flex-shrink-0"
+          >
+            <GridIcon />
+          </a>
+          {onTitleClick ? (
+            <button
+              type="button"
+              onClick={onTitleClick}
+              className="font-semibold text-brand-600 hover:text-brand-700 transition-colors"
+            >
+              {title}
+            </button>
+          ) : (
+            <span className="font-semibold text-brand-600">{title}</span>
+          )}
+        </div>
+
+        {/* Right: optional nav pills + language picker + children slot */}
+        <div className="flex items-center gap-1 min-w-0">
+          {navItems && navItems.length > 0 && (
+            <nav className="flex items-center gap-0.5 mr-1">
+              {navItems.map(item => (
+                <button
+                  key={item.key}
+                  type="button"
+                  onClick={item.onClick}
+                  className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors whitespace-nowrap ${
+                    item.active
+                      ? 'bg-brand-50 text-brand-700'
+                      : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700'
+                  }`}
+                >
+                  {item.label}
+                </button>
+              ))}
+            </nav>
+          )}
+
+          <LanguagePicker />
+
+          {children}
+        </div>
+
+      </div>
+    </header>
+  )
+}

--- a/src/components/LanguagePicker.tsx
+++ b/src/components/LanguagePicker.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+/**
+ * Copy this file into src/components/ when adopting in an app.
+ * Requires: react-i18next, configured with en / es / be / ru locales.
+ */
+
+const LANGUAGES = [
+  { code: 'en', label: 'EN' },
+  { code: 'es', label: 'ES' },
+  { code: 'be', label: 'BE' },
+  { code: 'ru', label: 'RU' },
+] as const
+
+type LangCode = (typeof LANGUAGES)[number]['code']
+
+function currentCode(language: string): LangCode {
+  const code = language.slice(0, 2) as LangCode
+  return LANGUAGES.some(l => l.code === code) ? code : 'en'
+}
+
+export default function LanguagePicker() {
+  const { i18n } = useTranslation()
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+  const active = LANGUAGES.find(l => l.code === currentCode(i18n.language))!
+
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [open])
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') { setOpen(false); return }
+    if (!open && (e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowDown')) {
+      e.preventDefault(); setOpen(true); return
+    }
+    if (open && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {
+      e.preventDefault()
+      const idx = LANGUAGES.findIndex(l => l.code === currentCode(i18n.language))
+      const next = e.key === 'ArrowDown'
+        ? (idx + 1) % LANGUAGES.length
+        : (idx - 1 + LANGUAGES.length) % LANGUAGES.length
+      i18n.changeLanguage(LANGUAGES[next].code)
+    }
+  }
+
+  return (
+    <div ref={ref} className="relative" onKeyDown={handleKeyDown}>
+      <button
+        type="button"
+        onClick={() => setOpen(v => !v)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-sm font-medium text-gray-600 hover:bg-gray-100 transition-colors select-none"
+      >
+        <span>{active.label}</span>
+        <svg className={`w-3 h-3 text-gray-400 transition-transform ${open ? 'rotate-180' : ''}`} viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5">
+          <path d="M2 4l4 4 4-4" strokeLinecap="round" strokeLinejoin="round"/>
+        </svg>
+      </button>
+
+      {open && (
+        <ul
+          role="listbox"
+          aria-label="Language"
+          className="absolute right-0 top-full mt-1 bg-white border border-gray-200 rounded-xl shadow-lg py-1 z-50 min-w-[110px]"
+        >
+          {LANGUAGES.map(lang => {
+            const isCurrent = lang.code === currentCode(i18n.language)
+            return (
+              <li
+                key={lang.code}
+                role="option"
+                aria-selected={isCurrent}
+              >
+                <button
+                  type="button"
+                  onClick={() => { i18n.changeLanguage(lang.code); setOpen(false) }}
+                  className={`w-full flex items-center gap-2 px-3 py-1.5 text-sm transition-colors ${
+                    isCurrent
+                      ? 'bg-brand-50 text-brand-700 font-semibold'
+                      : 'text-gray-700 hover:bg-gray-50'
+                  }`}
+                >
+                  <span>{lang.label}</span>
+                  {isCurrent && (
+                    <svg className="ml-auto w-3.5 h-3.5 text-brand-600" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="2">
+                      <path d="M2 7l3.5 3.5L12 3" strokeLinecap="round" strokeLinejoin="round"/>
+                    </svg>
+                  )}
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
Automated agent commit — see BRIEF.md.

Replaces the inline cycle-button header in `App.tsx` with the shared design-system `AppHeader` + `LanguagePicker` components.

**Changes:**
- `src/components/AppHeader.tsx` — copied from design-system
- `src/components/LanguagePicker.tsx` — copied from design-system
- `src/App.tsx` — replaced inline `<header>` block with `<AppHeader title onTitleClick navItems>`; navItems include active state and hide on home screen; removed cycle-button language switcher logic
- Also installed missing `html2canvas` dep to fix pre-existing build error

Closes #21

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXdJe6TuRNvNSNGfoUmfS5)_